### PR TITLE
Code for issue #2

### DIFF
--- a/searchreplacedb2.php
+++ b/searchreplacedb2.php
@@ -400,7 +400,7 @@ function icit_srdb_define_find( $filename = 'wp-config.php' ) {
 		// preventing the full WP stack from bootstrapping
 		stream_filter_register("stopwpbootstrap", "stopwpbootstrap_filter");
 		
-		// by reading this file via the php filter protocoal,
+		// by reading this file via the php filter protocol,
 		// we can safely include wp-config.php in our function scope now 
 		include("php://filter/read=stopwpbootstrap/resource=$filename");
 	}


### PR DESCRIPTION
Here is my implementation to have PHP parse wp-config.php without bootstrapping the entire WP environment. It does not use eval, but instead uses a custom stream filter to modify the file as it gets included. You can see I was able to eliminate a lot of code and now it will deal with any wp-config file, regardless of if they are using string constants or anything else.
