### PR TITLE
Free memory for each page query when done with it.

### DIFF
--- a/searchreplacedb2.php
+++ b/searchreplacedb2.php
@@ -337,6 +337,9 @@ function icit_srdb_replacer( $connection, $search = '', $replace = '', $tables =
 					}
 
 				}
+
+				mysql_free_result( $data );
+
 			}
 		}
 


### PR DESCRIPTION
I don't claim a deep understanding of the script, but this addition fixed a "mysql client ran out of memory" error for me while running on a large wp_posts table.
