### PR TITLE
Update searchreplacedb2cli.php to remove junk output

### DIFF
--- a/searchreplacedb2cli.php
+++ b/searchreplacedb2cli.php
@@ -9,9 +9,11 @@
  * this script currently affects all tables in a db there are @TODOs below...
  */
 
+// Include main script.  Use output buffering to avoid the HTML that the script spews
+// out as part of its operation.  This is not relevant to the CLI version.
+ob_start();
 require_once('searchreplacedb2.php'); // include the proper srdb script
-
-echo "########################### Ignore Above ###############################\n\n";
+ob_end_clean();
 
 // source: https://github.com/interconnectit/Search-Replace-DB/blob/master/searchreplacedb2.php
 


### PR DESCRIPTION
Updated the CLI script to avoid any output that is generated by the web script from being displayed (using output buffering).  This removes the need for the large "ignore everything above this line" notice and makes the script play more nicely when part of an automated process.
