### PR TITLE
Add new function to detect if script are running on command-line environ...

### DIFF
--- a/searchreplacedb2.php
+++ b/searchreplacedb2.php
@@ -103,6 +103,16 @@ function check_table_array( $table = '' ){
 
 
 /**
+ * Used to check if the current script are running in a command-line environment.
+ *
+ * @return bool    true if is cli
+ */
+function is_cli(){
+        return (!isset($_SERVER['SERVER_SOFTWARE']) && (php_sapi_name() == 'cli' || (is_numeric($_SERVER['argc']) && $_SERVER['argc'] > 0)));
+}
+
+
+/**
  * Simply create a submit button with a JS confirm popup if there is need.
  *
  * @param string $text    Button string.
@@ -533,6 +543,7 @@ if ( $step == 5 ) {
 /*
  Send the HTML to the screen.
 */
+if( !is_cli() ):
 @header('Content-Type: text/html; charset=UTF-8');?>
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:dc="http://purl.org/dc/terms/" dir="ltr" lang="en-US">
@@ -892,3 +903,4 @@ if ( ini_get( 'safe_mode' ) ) {
 	</div>
 </body>
 </html>
+<?php endif; ?>

--- a/searchreplacedb2cli.php
+++ b/searchreplacedb2cli.php
@@ -11,8 +11,6 @@
 
 require_once('searchreplacedb2.php'); // include the proper srdb script
 
-echo "########################### Ignore Above ###############################\n\n";
-
 // source: https://github.com/interconnectit/Search-Replace-DB/blob/master/searchreplacedb2.php
 
 /* Flags for options, all values required */


### PR DESCRIPTION
Hey guys, running the script via command-line I've noticed that the HTML output are showed as well. On searchreplacedb2cli.php you put a line with the text "############# Ignore Above ###############".

I think that we can detect if the script is running on command-line environment to remove the HTML output, without affect the main workflow of the script.

For these reason, I've forked the repo, made my change and set a new pull request, just to review if you consider this a good change to do over the script.

Any questions, please let me know.
