### PR TITLE
Change default of dry-run flag to false

### DIFF
--- a/srdb.class.php
+++ b/srdb.class.php
@@ -247,7 +247,7 @@ class icit_srdb {
 			'tables'			=> array(),
 			'exclude_cols' 		=> array(),
 			'include_cols' 		=> array(),
-			'dry_run' 			=> true,
+			'dry_run' 			=> false,
 			'regex' 			=> false,
 			'pagesize' 			=> 50000,
 			'alter_engine' 		=> false,

--- a/srdb.cli.php
+++ b/srdb.cli.php
@@ -4,7 +4,7 @@
 
 /**
  * To run this script, execute something like this:
- * `./srdb.cli.php -h localhost -u root -d test -s "findMe" -r "replaceMe"`
+ * `./srdb.cli.php -h localhost -u root -p test -s "findMe" -r "replaceMe"`
  * use the --dry-run flag to do a dry run without searching/replacing.
  */
 
@@ -223,7 +223,7 @@ It took {$time} seconds";
 $report = new icit_srdb_cli( $args );
 
 if ( $report && ( ( isset( $args[ 'dry_run' ] ) && $args[ 'dry_run' ] ) || empty( $report->errors[ 'results' ] ) ) ) {
-	echo "\nAnd we're done!";
+	echo "\nAnd we're done!\n\n";
 } else {
-	echo "\nCheck the output for errors. You may need to ensure verbose output is on by using -v or --verbose.";
+	echo "\nCheck the output for errors. You may need to ensure verbose output is on by using -v or --verbose.\n\n";
 }


### PR DESCRIPTION
Only very minor amends. You've created a really helpful tool. Thanks.

In  srdb.class.php, the default of dry-run was set to true, which prevented me from doing a live run.

And in srdb.cli.php, the -d in the top comment should be -p. I spent a little while trying to figure out what the -d flag was for!

Thanks again.
