### PR TITLE
Base64 encoded fields compatible

### DIFF
--- a/searchreplacedb2.php
+++ b/searchreplacedb2.php
@@ -229,8 +229,19 @@ function recursive_unserialize_replace( $from = '', $to = '', $data = '', $seria
 		}
 
 		else {
-			if ( is_string( $data ) )
-				$data = str_replace( $from, $to, $data );
+			if ( is_string( $data ) ) {
+				$fixed = $data;
+				$decode = base64_decode($data);
+				$encode = base64_encode($decode);
+				if ($data === $encode) { // Maybe this is a base64
+					$fixed = base64_encode(recursive_unserialize_replace( $from, $to, $decode, false ));
+				}
+				if ($data === $fixed) { // It was not a base64 or no changed, so try without decoding
+					$data = str_replace( $from, $to, $data );
+                } else {
+                    $data = $fixed;
+				}
+			}
 		}
 
 		if ( $serialised )

--- a/searchreplacedb2.php
+++ b/searchreplacedb2.php
@@ -197,7 +197,7 @@ function recursive_array_replace( $find, $replace, $data ) {
  *
  * @return array	The original array with all elements replaced as needed.
  */
-function recursive_unserialize_replace( $from = '', $to = '', $data = '', $serialised = false ) {
+function recursive_unserialize_replace( $from = '', $to = '', $data = '', $serialised = false, $jsonencoded = false ) {
 
 	// some unseriliased data cannot be re-serialised eg. SimpleXMLElements
 	try {

--- a/searchreplacedb2.php
+++ b/searchreplacedb2.php
@@ -239,7 +239,7 @@ function recursive_unserialize_replace( $from = '', $to = '', $data = '', $seria
 				$decode = base64_decode($data);
 				$encode = base64_encode($decode);
 				if ($data === $encode) { // Maybe this is a base64
-					$fixed = base64_encode(recursive_unserialize_replace( $from, $to, $decode, false ));
+					$fixed = base64_encode(recursive_unserialize_replace( $from, $to, $decode ));
 				}
 				if ($data === $fixed) { // It was not a base64 or no changed, so try without decoding
 					$data = str_replace( $from, $to, $data );

--- a/searchreplacedb2.php
+++ b/searchreplacedb2.php
@@ -243,8 +243,8 @@ function recursive_unserialize_replace( $from = '', $to = '', $data = '', $seria
 				}
 				if ($data === $fixed) { // It was not a base64 or no changed, so try without decoding
 					$data = str_replace( $from, $to, $data );
-                } else {
-                    $data = $fixed;
+				} else {
+					$data = $fixed;
 				}
 			}
 		}

--- a/searchreplacedb2.php
+++ b/searchreplacedb2.php
@@ -202,11 +202,11 @@ function recursive_unserialize_replace( $from = '', $to = '', $data = '', $seria
 	// some unseriliased data cannot be re-serialised eg. SimpleXMLElements
 	try {
 
-		if ( is_string( $data ) && ( $unserialized = @unserialize( $data ) ) !== false ) {
+		if ( is_string( $data ) && !empty($data) && ( $unserialized = @unserialize( $data ) ) !== false ) {
 			$data = recursive_unserialize_replace( $from, $to, $unserialized, true );
 		}
 
-		elseif ( is_string( $data ) && function_exists('json_decode') &&
+		elseif ( is_string( $data ) && !empty($data) && function_exists('json_decode') &&
 			   ( $unjson = @json_decode( $data ) ) !== null ) {
 			$data = recursive_unserialize_replace( $from, $to, $unjson, false, true );
 		}

--- a/searchreplacedb2.php
+++ b/searchreplacedb2.php
@@ -206,6 +206,11 @@ function recursive_unserialize_replace( $from = '', $to = '', $data = '', $seria
 			$data = recursive_unserialize_replace( $from, $to, $unserialized, true );
 		}
 
+		elseif ( is_string( $data ) && function_exists('json_decode') &&
+			   ( $unjson = @json_decode( $data ) ) !== null ) {
+			$data = recursive_unserialize_replace( $from, $to, $unjson, false, true );
+		}
+		
 		elseif ( is_array( $data ) ) {
 			$_tmp = array( );
 			foreach ( $data as $key => $value ) {
@@ -246,6 +251,9 @@ function recursive_unserialize_replace( $from = '', $to = '', $data = '', $seria
 
 		if ( $serialised )
 			return serialize( $data );
+
+		if ( $jsonencoded && function_exists('json_encode') )
+			return json_encode( $data );
 
 	} catch( Exception $error ) {
 


### PR DESCRIPTION
Support search and replace in base64 encoded fields, like NextGen Gallery plugin data in WP post table.
References:
* https://gist.github.com/deltafactory/6789297
* http://wordpress.org/support/topic/nextgen-is-requesting-the-wrong-url-adress

This is compatible with any application that saves data in DB using base64 codification 