### PR TITLE
Escaping $search and $replace in get_report()

### DIFF
--- a/index.php
+++ b/index.php
@@ -682,8 +682,8 @@ class icit_srdb_ui extends icit_srdb {
 		$time = array_sum( explode( ' ', $report[ 'end' ] ) ) - array_sum( explode( ' ', $report[ 'start' ] ) );
 
 		$srch_rplc_input_phrase = $dry_run ?
-			'searching for <strong>"' . $search . '"</strong> (to be replaced by <strong>"' . $replace . '"</strong>)' :
-			'replacing <strong>"' . $search . '"</strong> with <strong>"' . $replace . '"</strong>';
+			'searching for <strong>"' . $this->esc_html_attr($search) . '"</strong> (to be replaced by <strong>"' . $this->esc_html_attr($replace) . '"</strong>)' :
+			'replacing <strong>"' . $this->esc_html_attr($search) . '"</strong> with <strong>"' . $this->esc_html_attr($replace) . '"</strong>';
 
 		echo '
 		<div class="report">';


### PR DESCRIPTION
I've been looking through the code in preparation for using this on a project and came across some unescaped usage of $search and $replace in the function get_report(). Most of the UI appears to be using JS to show the report so it's unclear to me the circumstances in which this might be used, but the values should be escaped if they are ever used.
