### PR TITLE
Fixed bug with PDO detection and mysql driver

### DIFF
--- a/srdb.class.php
+++ b/srdb.class.php
@@ -380,7 +380,15 @@ class icit_srdb {
 	 */
 	public function db_setup() {
 
-		$connection_type = class_exists( 'PDO' ) ? 'pdo' : 'mysql';
+		//default to mysql
+		$connection_type = 'mysql';
+
+		//try to use pdo if we can
+		if ( class_exists( 'PDO' ) ) {
+			$drivers = PDO::getAvailableDrivers();
+			if ( array_search( 'mysql', $drivers ) !== false )
+				$connection_type = 'pdo';
+		}
 
 		// connect
 		$this->set( 'db', $this->connect( $connection_type ) );


### PR DESCRIPTION
the db_setup() method was checking for the existence of the PDO class and using it if it exists. However, just because PDO exists doesn't mean that the mysql driver for it is enabled (the pdo_mysql driver can be disabled in the php.ini). If the mysql driver is disabled, the user will get a "could not find driver" error.

This update changes the behavior of the db_setup() function such that it will only use the pdo classes for database connectivity if the PDO class exists AND the mysql driver for pdo is available. Otherwise it will fall back to use the standard mysql methods for database connectivity.

This will allow the user to continue using the tool even when the pdo_mysql driver is not available.