### PR TITLE
Fixed non-regexp preview to use dumb string replacement

### DIFF
--- a/index.php
+++ b/index.php
@@ -2675,14 +2675,17 @@ class icit_srdb_ui extends icit_srdb {
 											} );
 										} else {
                                             from_div = $change.find('.from');
-                                            
-                                            from_div.html( from_div.html().replace( new RegExp( search, 'g' ), '<span class="highlight">' + search + '</span>' ) );
+											
+											// do a multiple straight up search replace on search with the highlight string we want to put in.
+											var original_chunks = from_div.html().split(search);
+											
+                                            from_div.html( original_chunks.join('<span class="highlight">' + search + '</span>') );
                                             
                                             if (replace)
                                             {
                                             to_div = $change.find('.to');
                                             
-                                            to_div.html( to_div.html().replace( new RegExp( replace, 'g' ), '<span class="highlight">' + replace + '</span>' ) );
+                                            to_div.html( original_chunks.join('<span class="highlight">' + replace + '</span>') );
                                             }
 										}
 										return true;


### PR DESCRIPTION
Internal case 7688.

This fixed weird errors that manifest when using characters that might be interpreted as RE symbols, and also prevents the Replace pane from incorrectly showing things that match the Replace string, but weren't actually produced due to replacement.