### PR TITLE
User can exclude tables

### DIFF
--- a/index.php
+++ b/index.php
@@ -245,6 +245,8 @@ class icit_srdb_ui extends icit_srdb {
 		if ( isset( $_POST[ 'use_tables' ] ) && $_POST[ 'use_tables' ] == 'all' )
 			$tables = array();
 
+		$exclude_tables = isset( $_POST[ 'exclude_tables' ] ) && is_array( $_POST[ 'exclude_tables' ] ) ? $_POST[ 'exclude_tables' ] : array( );
+
 		// exclude / include columns
 		$exclude_cols = isset( $_POST[ 'exclude_cols' ] ) ? $_POST[ 'exclude_cols' ] : array();
 		$include_cols = isset( $_POST[ 'include_cols' ] ) ? $_POST[ 'include_cols' ] : array();
@@ -257,7 +259,7 @@ class icit_srdb_ui extends icit_srdb {
 		// update class vars
 		$vars = array(
 			'name', 'user', 'pass', 'host', 'port',
-			'charset', 'collate', 'tables',
+			'charset', 'collate', 'tables', 'exclude_tables',
 			'search', 'replace',
 			'exclude_cols', 'include_cols',
 			'regex', 'regex_i', 'regex_m', 'regex_s', 'regex_x'
@@ -338,6 +340,7 @@ class icit_srdb_ui extends icit_srdb {
 					'search' => $this->get( 'search' ),
 					'replace' => $this->get( 'replace' ),
 					'tables' => $this->get( 'tables' ),
+					'exclude_tables' => $this->get( 'exclude_tables' ),
 					'dry_run' => $this->get( 'dry_run' ),
 					'regex' => $this->get( 'regex' ),
 					'exclude_cols' => $this->get( 'exclude_cols' ),
@@ -904,12 +907,12 @@ class icit_srdb_ui extends icit_srdb {
 	}
 
 
-	public function table_select( $echo = true ) {
+	public function table_select( $echo = true, $name = "tables" ) {
 
 		$table_select = '';
 
 		if ( ! empty( $this->all_tables ) ) {
-			$table_select .= '<select name="tables[]" multiple="multiple">';
+			$table_select .= '<select name="'.$name.'[]" multiple="multiple">';
 			foreach( $this->all_tables as $table ) {
 				$size = $table[ 'Data_length' ] / 1000;
 				$size_unit = 'kb';
@@ -1041,7 +1044,7 @@ class icit_srdb_ui extends icit_srdb {
 						</label>
 					</div>
 
-					<div class="field table-select hide-if-js"><?php $this->table_select(); ?></div>
+					<div class="field table-select hide-if-js table-select-include"><?php $this->table_select(); ?></div>
 
 				</div>
 
@@ -2043,6 +2046,8 @@ class icit_srdb_ui extends icit_srdb {
 								dom.on( 'click', '[name="use_tables"]', t.toggle_tables );
 								dom.find( '[name="use_tables"][checked]' ).click();
 
+								dom.on( 'click', '[name="use_exclude_tables"]', t.toggle_exclude_tables );
+
 								// toggle regex mode
 								dom.on( 'click', '[name="regex"]', t.toggle_regex );
 								dom.find( '[name="regex"][checked]' ).click();
@@ -2110,10 +2115,14 @@ class icit_srdb_ui extends icit_srdb {
 
 						toggle_tables: function() {
 							if ( this.id == 'all_tables' ) {
-								dom.find( '.table-select' ).slideUp( 400 );
+								dom.find( '.table-select-include' ).slideUp( 400 );
 							} else {
-								dom.find( '.table-select' ).slideDown( 400 );
+								dom.find( '.table-select-include' ).slideDown( 400 );
 							}
+						},
+
+						toggle_exclude_tables: function() {
+							dom.find( '.table-select-exclude' ).slideToggle( 400 );
 						},
 
 						toggle_regex: function() {
@@ -2216,6 +2225,14 @@ class icit_srdb_ui extends icit_srdb {
 							if ( ! $.isArray( data[ 'tables[]' ] ) )
 								data[ 'tables[]' ] = [ data[ 'tables[]' ] ];
 
+							// check we don't just have one table selected as we get a string not array
+							if (! data[ 'exclude_tables[]' ] || ! data[ 'exclude_tables[]' ].length) {
+								data[ 'exclude_tables[]' ] = [];
+							} 
+							else if ( ! $.isArray( data[ 'exclude_tables[]' ] ) ) {
+								data[ 'exclude_tables[]' ] = [ data[ 'exclude_tables[]' ] ];
+							}
+
 							// add in ajax and submit params
 							data = $.extend( {
 								ajax: true,
@@ -2311,6 +2328,12 @@ class icit_srdb_ui extends icit_srdb {
 								return false;
 							}
 
+							if ($.inArray(data[ 'tables[]' ][ i ], data[ 'exclude_tables[]' ] ) !== -1) {
+								console.log('on ignore la table : ' + data[ 'tables[]' ][ i ]);
+								t.recursive_fetch_json( data, ++i );
+								return false;
+							}
+				
 							// clone data
 							var post_data = $.extend( true, {}, data ),
 								dry_run = data.submit != 'submit[liverun]',

--- a/srdb.class.php
+++ b/srdb.class.php
@@ -113,6 +113,11 @@ class icit_srdb {
 	public $tables = array();
 
 	/**
+	 * @var array Tables to exclude
+	 */
+	public $exclude_tables = array();
+
+	/**
 	 * @var string Search term
 	 */
 	public $search = false;
@@ -255,6 +260,7 @@ class icit_srdb {
 			'search' 			=> '',
 			'replace' 			=> '',
 			'tables'			=> array(),
+			'exclude_tables'		=> array(),
 			'exclude_cols' 		=> array(),
 			'include_cols' 		=> array(),
 			'dry_run' 			=> true,
@@ -272,7 +278,7 @@ class icit_srdb {
 		set_error_handler( array( $this, 'errors' ), E_ERROR | E_WARNING );
 
 		// allow a string for columns
-		foreach( array( 'exclude_cols', 'include_cols', 'tables' ) as $maybe_string_arg ) {
+		foreach( array( 'exclude_cols', 'include_cols', 'tables', 'exclude_tables' ) as $maybe_string_arg ) {
 			if ( is_string( $args[ $maybe_string_arg ] ) )
 				$args[ $maybe_string_arg ] = array_filter( array_map( 'trim', explode( ',', $args[ $maybe_string_arg ] ) ) );
 		}
@@ -327,7 +333,7 @@ class icit_srdb {
 
 			// default search/replace action
 			else {
-				$report = $this->replacer( $this->search, $this->replace, $this->tables );
+				$report = $this->replacer( $this->search, $this->replace, $this->tables, $this->exclude_tables );
 			}
 
 		} else {
@@ -800,7 +806,7 @@ class icit_srdb {
 	 *
 	 * @return array    Collection of information gathered during the run.
 	 */
-	public function replacer( $search = '', $replace = '', $tables = array( ) ) {
+	public function replacer( $search = '', $replace = '', $tables = array( ), $exclude_tables = array( ) ) {
 
 		// check we have a search string, bail if not
 		if ( empty( $search ) ) {
@@ -842,6 +848,11 @@ class icit_srdb {
 		if ( is_array( $tables ) && ! empty( $tables ) ) {
 
 			foreach( $tables as $table ) {
+
+				if (in_array($table, $exclude_tables)) {
+					$this->add_error('Ignoring table : ' . $table);
+					continue;
+				}
 
 				$encoding = $this->get_table_character_set( $table );
 				switch( $encoding ) {

--- a/srdb.cli.php
+++ b/srdb.cli.php
@@ -22,6 +22,7 @@ $opts = array(
 	's:' => 'search:',
 	'r:' => 'replace:',
 	't:' => 'tables:',
+	'w:' => 'exclude-tables:',
 	'i:' => 'include-cols:',
 	'x:' => 'exclude-cols:',
 	'g' => 'regex',


### PR DESCRIPTION
Web & CLI version modified in order to allow user to exclude some tables.

It is sometimes easier to exclude a few tables than select all the other ones. Especially with an automatic shell script for example.

This PR is for review. It lacks documentation/comments. I added this feature on "replace" only and not on InnoDB or UTF8 methods as I do not use it. Also, I chose the letter `w` as the new option for the CLI script but it could be better to chose something else. It's up to you. 

I think this feature could be useful to others, it is to me. 
