### PR TITLE
Fix AJAX errors when altering collation on tables

### DIFF
--- a/srdb.class.php
+++ b/srdb.class.php
@@ -1042,8 +1042,9 @@ class icit_srdb {
 
 			$report = array( 'engine' => $engine, 'converted' => array() );
 
+			$all_tables = $this->get_tables();
+			
 			if ( empty( $tables ) ) {
-				$all_tables = $this->get_tables();
 				$tables = array_keys( $all_tables );
 			}
 
@@ -1092,8 +1093,9 @@ class icit_srdb {
 
 			$report = array( 'collation' => $collation, 'converted' => array() );
 
+			$all_tables = $this->get_tables();
+				
 			if ( empty( $tables ) ) {
-				$all_tables = $this->get_tables();
 				$tables = array_keys( $all_tables );
 			}
 


### PR DESCRIPTION
Fix AJAAX errors when altering collation on tables: move the get_tables call out of the conditional to ensure that the mapping from table names to table infos is always available.

This fixes errors that were caused when trying to alter the collation of a single table - the all_tables wouldn't have been populated and the AJAX response from the server was mangled by the immediate output of a PHP notice.