### PR TITLE
Docker container support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 MAINTAINER Fer Uria <fauria@gmail.com>
 LABEL Description="Search Replace DB tool Docker image" \
 	License="GPL v3" \
-	Usage="docker run -i -t --rm -p 8080:80 fauria/srdb" \
+	Usage="docker run -i -t --rm -p 8080:80 --link mysql-container:mysql fauria/srdb" \
 	Version="1.0"
 
 RUN apt-get update

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
 FROM ubuntu:16.04
 MAINTAINER Fer Uria <fauria@gmail.com>
-LABEL Description="XYZ" \
-	License="Apache License 2.0" \
-	Usage="XYZ" \
+LABEL Description="Search Replace DB tool Docker image" \
+	License="GPL v3" \
+	Usage="docker run -i -t --rm -p 8080:80 fauria/srdb" \
 	Version="1.0"
 
 RUN apt-get update
 RUN apt-get upgrade -y
 
-RUN apt-get install -y php5.6 php5.6-mysql apache2 libapache2-mod-php5.6 wget unzip
+RUN apt-get install -y php5 php5-mysql apache2 libapache2-mod-php5 wget unzip
 
-RUN wget https://github.com/fauria/Search-Replace-DB/archive/master.zip -P /var/www
+RUN wget https://github.com/interconnectit/Search-Replace-DB/archive/master.zip -P /var/www
 RUN rm -rf /var/www/html
 RUN unzip /var/www/master.zip -d /var/www
 RUN mv /var/www/Search-Replace-DB-master /var/www/html
@@ -19,4 +19,4 @@ RUN chown -R www-data:www-data /var/www/html
 VOLUME /var/www/html
 EXPOSE 80
 
-ENTRYPOINT ["/usr/sbin/apachectl", "-k", "start"]
+ENTRYPOINT ["/usr/sbin/apachectl", "-DFOREGROUND", "-k", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:16.04
+MAINTAINER Fer Uria <fauria@gmail.com>
+LABEL Description="XYZ" \
+	License="Apache License 2.0" \
+	Usage="XYZ" \
+	Version="1.0"
+
+RUN apt-get update
+RUN apt-get upgrade -y
+
+RUN apt-get install -y php5.6 php5.6-mysql apache2 libapache2-mod-php5.6 wget unzip
+
+RUN wget https://github.com/fauria/Search-Replace-DB/archive/master.zip -P /var/www
+RUN rm -rf /var/www/html
+RUN unzip /var/www/master.zip -d /var/www
+RUN mv /var/www/Search-Replace-DB-master /var/www/html
+RUN chown -R www-data:www-data /var/www/html
+
+VOLUME /var/www/html
+EXPOSE 80
+
+ENTRYPOINT ["/usr/sbin/apachectl", "-k", "start"]

--- a/index.php
+++ b/index.php
@@ -729,7 +729,7 @@ class icit_srdb_ui extends icit_srdb {
 	/**
 	 * Attempts to detect a Docker container and bootstraps the environment with it
 	 *
-	 * @return bool    Whether it is a Wordpress container and we have database linked
+	 * @return bool    Whether it is a Docker container and we have a linked database
 	 */
 	public function is_docker() {
 		

--- a/index.php
+++ b/index.php
@@ -738,7 +738,7 @@ class icit_srdb_ui extends icit_srdb {
 		putenv('MYSQL_PORT_3306_TCP_PORT=3306');
 		putenv('MYSQL_PORT_3306_TCP_ADDR=172.17.0.67');
 
-		if ( 1 === 1 || file_exists( '/.dockerenv' ) && file_exists( '/.dockerinit' ) ) {
+		if ( file_exists( '/.dockerenv' ) && file_exists( '/.dockerinit' ) ) {
 
 			if ( getenv( 'MYSQL_ENV_MYSQL_VERSION' ) ) {
 


### PR DESCRIPTION
Hi! 

I have created a Dockerfile to simplify the task of running Search-Replace-DB from a Docker container. 

A new method `is_docker()` has been added. It determines if the script is running inside a container with a linked MySQL database. If so, defines the DB params in the same fashion as `is_wordpress()` does.
