### PR TITLE
Mysql socket gna

### DIFF
--- a/index.php
+++ b/index.php
@@ -153,7 +153,10 @@ class icit_srdb_ui extends icit_srdb {
 			$pass 		= DB_PASSWORD;
 
 			// Port and host need to be split apart.
-			if ( strstr( DB_HOST, ':' ) !== false ) {
+			if ( substr(DB_HOST, 0, 10) === 'localhost:' ) {
+				$host = DB_HOST;
+				$port = 0;
+			} elseif ( strstr( DB_HOST, ':' ) !== false ) {
 				$parts = explode( ':', DB_HOST );
 				$host = $parts[0];
 				$port_input = $parts[1];

--- a/srdb.class.php
+++ b/srdb.class.php
@@ -173,6 +173,7 @@ class icit_srdb {
 	public $port = 0;
 	public $charset = 'utf8';
 	public $collate = '';
+	public $socket = '/tmp/mysql.sock';
 
 
 	/**
@@ -283,7 +284,12 @@ class icit_srdb {
 			if ( is_string( $args[ $maybe_string_arg ] ) )
 				$args[ $maybe_string_arg ] = array_filter( array_map( 'trim', explode( ',', $args[ $maybe_string_arg ] ) ) );
 		}
-		
+
+		// handle localhost:/tmp/mysql.sock as host
+		if ( substr((string)$args['host'], 0, 10) === 'localhost:' ) {
+                        (string)$args['socket'] = substr((string)$args['host'], 10);
+                       (string)$args['port'] = "0";
+               }
 		// verify that the port number is logical		
 		// work around PHPs inability to stringify a zero without making it an empty string
 		// AND without casting away trailing characters if they are present.
@@ -466,9 +472,13 @@ class icit_srdb {
 
 		// switch off PDO
 		$this->set( 'use_pdo', false );
-
-		$connection = @mysqli_connect( $this->host, $this->user, $this->pass, $this->name, $this->port );
-
+		// If host starts with "localhost:" use the part after it as path to mysql-socket
+		if ( substr($this->host, 0, 10) === 'localhost:' ) {
+                       $this->socket = substr($this->host, 10);
+                       $connection = @mysqli_connect( '', $this->user, $this->pass, $this->name, '', $this->socket );
+		} else {
+                       $connection = @mysqli_connect( $this->host, $this->user, $this->pass, $this->name, $this->port );
+               }
 		// unset if not available
 		if ( ! $connection ) {
 			$this->add_error( mysqli_connect_error( ), 'db' );
@@ -487,7 +497,13 @@ class icit_srdb {
 	public function connect_pdo() {
 	
 		try {
-			$connection = new PDO( "mysql:host={$this->host};port={$this->port};dbname={$this->name}", $this->user, $this->pass );
+			// If host starts with "localhost:" use the part after it as path to mysql-socket
+			if ( substr($this->host, 0, 10) === 'localhost:' ) {
+				$this->socket = substr($this->host, 10);
+				$connection = new PDO( "mysql:unix_socket={$this->socket};dbname={$this->name}", $this->user, $this->pass );
+			} else {
+				$connection = new PDO( "mysql:host={$this->host};port={$this->port};dbname={$this->name}", $this->user, $this->pass );
+			}
 		} catch( PDOException $e ) {
 			$this->add_error( $e->getMessage(), 'db' );
 			$connection = false;


### PR DESCRIPTION
The german hosting company 1&1 allows in most of their packages connection to MySQL only trough local socket, and this prevents Search-Replace-DB from connecting to MySQL.
To solve this problem, i had to set the $host to the exact string provided by 1&1, which was in my case

`localhost:/tmp/mysql5.sock`

and based on this the **localhost:** string is stripped, and the resulting value is assigned to $socket, also $port is set to 0 (zero), but the value of $host is left AS-IS, to allow the differentiation also in the connect functions, this way my changes are not limited to _/tmp/mysql5.sock_ but any path to the socket can be provided

These changes are based on the patch i presented in issue #145 
