### PR TITLE
add slashes to all CLI args before they're removed in parent constructor

### DIFF
--- a/srdb.cli.php
+++ b/srdb.cli.php
@@ -177,7 +177,15 @@ foreach( $options as $key => $value ) {
 // modify the log output
 class icit_srdb_cli extends icit_srdb {
 
-	public function log( $type = '' ) {
+    public function __construct($args) {
+        //add slashes to all args before they're removed in parent constructor
+        foreach ($args as $key => $value) {
+            $args[$key] = addslashes($value);
+        }
+        parent::__construct($args);
+    }
+
+    public function log( $type = '' ) {
 
 		$args = array_slice( func_get_args(), 1 );
 


### PR DESCRIPTION
Regex escape backslashes are being removed from the search string in the parent constructor:
https://github.com/interconnectit/Search-Replace-DB/blob/master/srdb.class.php#L303

This PR adds slashes to the CLI arguments before they are passed to the parent constructor.

Previously, regex search string like "/http:\/\/example.com/i" would be converted to '/http://example.com/i' before being passed to the preg_replace(). This results in a "preg_replace(): Unknown modifier '/' error.
