### PR TITLE
WordPress Boostrap Path Incorrect - Script Dir not needed

### DIFF
--- a/index.php
+++ b/index.php
@@ -745,7 +745,7 @@ class icit_srdb_ui extends icit_srdb
                     batcache_cancel();
 
 // bootstrap WordPress
-                require(dirname(__FILE__) . "{$wp_path}/{$bootstrap_file}");
+                require("{$wp_path}/{$bootstrap_file}");
 
                 $this->set('path', ABSPATH);
 

--- a/tests/SrdbTest.php
+++ b/tests/SrdbTest.php
@@ -34,7 +34,7 @@ class SrdbTest extends PHPUnit_Extensions_Database_TestCase {
 		parent::setUp();
 
 		// get class to test
-		require_once(dirname(__FILE__) . '/../src/srdb.class.php');
+		require_once(dirname(__FILE__) . '/../srdb.class.php');
 	}
 
 	public function tearDown() {


### PR DESCRIPTION
Edited require path for wordpress boostrap, as previous setup was causing a path pointing at the scripts's own folder with the actual require path for the wordpress script to be added on the end.