### PR TITLE
More accurate comparison for data changes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = tab
+indent_size = 4

--- a/srdb.class.php
+++ b/srdb.class.php
@@ -917,6 +917,8 @@ class icit_srdb {
 							{
 								$raw_data = serialize(unserialize($raw_data));
 							}
+							$edited_data = $data_to_fix = $raw_data;
+
 
 							if ( in_array( $column, $primary_key ) ) {
 								$where_sql[] = "`{$column}` = " . $this->db_escape( $data_to_fix );

--- a/srdb.class.php
+++ b/srdb.class.php
@@ -912,7 +912,11 @@ class icit_srdb {
 
 						foreach( $columns as $column ) {
 
-							$edited_data = $data_to_fix = $row[ $column ];
+							$raw_data = $row[$column];
+							if(@unserialize($raw_data)!==false)
+							{
+								$raw_data = serialize(unserialize($raw_data));
+							}
 
 							if ( in_array( $column, $primary_key ) ) {
 								$where_sql[] = "`{$column}` = " . $this->db_escape( $data_to_fix );


### PR DESCRIPTION
I noticed in some cases `serialize(unserialize($data)) == $data` is not always true. I think it may differ by PHP versions. For example, the output of `serialize` in PHP5 might differ from PHP6, even though both support the same serialization format. 

So, I added an initial call to `unserialize` so true changes are detected better.