### PR TITLE
Fix include

### DIFF
--- a/index.php
+++ b/index.php
@@ -745,7 +745,7 @@ class icit_srdb_ui extends icit_srdb
                     batcache_cancel();
 
 // bootstrap WordPress
-                require(dirname(__FILE__) . "{$wp_path}/{$bootstrap_file}");
+                require("{$wp_path}/{$bootstrap_file}");
 
                 $this->set('path', ABSPATH);
 


### PR DESCRIPTION
Removed dirname(__FILE__) because it create a wrong path
dirname(__FILE__) is called before at https://github.com/interconnectit/Search-Replace-DB/blob/4.0/index.php#L704