### PR TITLE
PHP 7 simple fix. Force variable to be a number before perform a math function

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,13 @@
 {
-	"name": "interconnectit/search-replace-db",
+	"name": "guigaba/search-replace-db",
 	"description": "A PHP search replace tool for quickly modifying a string throughout a database. Useful for changing the base URL when migrating a WordPress site from development to production.",
 	"license": "GPL-3.0",
 	"homepage": "https://github.com/interconnectit/Search-Replace-DB",
 	"require": {
-		"php": ">=5.3.0"
+		"php": ">=7"
 	},
 	"support": {
-		"issues": "https://github.com/interconnectit/Search-Replace-DB/issues"
+		"issues": "https://github.com/guigaba/Search-Replace-DB/issues"
 	},
 	"bin": [ "srdb.cli.php" ],
 	"autoload": {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,13 @@
 	"name": "guigaba/search-replace-db",
 	"description": "A PHP search replace tool for quickly modifying a string throughout a database. Useful for changing the base URL when migrating a WordPress site from development to production.",
 	"license": "GPL-3.0",
-	"homepage": "https://github.com/interconnectit/Search-Replace-DB",
+	"homepage": "https://github.com/guigaba/Search-Replace-DB",
+	"repositories": [
+		{
+			"type": "vcs",
+			"url": "https://github.com/guigaba/Search-Replace-DB"
+		}
+	],
 	"require": {
 		"php": ">=7"
 	},

--- a/srdb.cli.php
+++ b/srdb.cli.php
@@ -194,12 +194,12 @@ class icit_srdb_cli extends icit_srdb {
 				break;
 			case 'search_replace_table_end':
 				list( $table, $report ) = $args;
-				$time = number_format( $report[ 'end' ] - $report[ 'start' ], 8 );
-				$output .= "{$table}: {$report['rows']} rows, {$report['change']} changes found, {$report['updates']} updates made in {$time} seconds";
-				break;
-			case 'search_replace_end':
-				list( $search, $replace, $report ) = $args;
-				$time = number_format( $report[ 'end' ] - $report[ 'start' ], 8 );
+                $time = number_format( floatval($report[ 'end' ]) - floatval($report[ 'start' ]), 8 );
+                $output .= "{$table}: {$report['rows']} rows, {$report['change']} changes found, {$report['updates']} updates made in {$time} seconds";
+                break;
+            case 'search_replace_end':
+                list( $search, $replace, $report ) = $args;
+                $time = number_format( floatval($report[ 'end' ]) - floatval($report[ 'start' ]), 8 );
 				$dry_run_string = $this->dry_run ? "would have been" : "were";
 				$output .= "
 Replacing {$search} with {$replace} on {$report['tables']} tables with {$report['rows']} rows


### PR DESCRIPTION
Problem:
With PHP7 type declaration changes, the function number_format needs to ensure that the given variable is actually a number. 

On the lines 197,202 the library uses the number_format function to format the difference between the start time and the end time.

That being said, a simple solution is to force the given argument to be a number by extracting the float value of the variable before send it to the number_format function.

Diff:
srdb.cli.php
```
197:     -     $time = number_format( $report[ 'end' ] - $report[ 'start' ], 8 );
197:     +     $time = number_format( floatval($report[ 'end' ]) - floatval($report[ 'start' ]), 8 );
...

202:     -     $time = number_format( $report[ 'end' ] - $report[ 'start' ], 8 );
202:     +     $time = number_format( floatval($report[ 'end' ]) - floatval($report[ 'start' ]), 8 );
``` 