### PR TITLE
Fix for #241.

### DIFF
--- a/srdb.class.php
+++ b/srdb.class.php
@@ -747,7 +747,7 @@ class icit_srdb {
 			}
 
 			// Submitted by Tina Matter
-			elseif ( is_object( $data ) ) {
+			elseif ( is_object( $data ) && ! is_a( $data, '__PHP_Incomplete_Class' ) ) {
 				// $data_class = get_class( $data );
 				$_tmp = $data; // new $data_class( );
 				$props = get_object_vars( $data );


### PR DESCRIPTION
As of PHP 7.2 `is_object( $data )` will return `true` rather than `false` if the object is a `__PHP_Incomplete_Class`. 

Therefore I've added an extra check for __PHP_Incomplete_Class where is_object is used.