### PR TITLE
Update README with php-mbstring troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,3 +146,4 @@ This happens occasionally and could be for a couple of reasons:
  * When the script starts, it attempts to start your WordPress or Drupal installation to auto-detect your username and password settings. If this fails, you will see a message informing you that auto-detection failed. You will have to enter your details manually.
  * Script was unable to set the timeout so PHP closed the connection before the table could be processed, this can happen on some server configurations.
  * When using php-fpm (as you have with VVV) make sure that the socket is owned by the server user `chown www-data:www-data /var/run/php5-fpm.sock`.
+ * php-mbstring must be installed 


### PR DESCRIPTION
Symptoms: AJAX error from web UI, "Call to undefined function mb_regex_encoding()" error from srdb.cli

https://github.com/interconnectit/Search-Replace-DB/issues/130#issuecomment-206207315 had the fix already, but I had to poke around to figure this out on a new server setup. After php-mbstring install, web UI worked. Should be in README