### PR TITLE
Use proper continue scope

### DIFF
--- a/srdb.class.php
+++ b/srdb.class.php
@@ -858,7 +858,7 @@ class icit_srdb {
 					case 'utf32':
 						//$encoding = 'utf8';
 						$this->add_error( "The table \"{$table}\" is encoded using \"{$encoding}\" which is currently unsupported.", 'results' );
-						continue;
+						continue 2;
 						break;
 
 					default:


### PR DESCRIPTION
See https://wiki.php.net/rfc/continue_on_switch_deprecation for the longer story, but to have the C-like behavior of continue referring to the for-loop, we need to use `continue 2` here.