### PR TITLE
fix for non well formed numeric value encountered php notices

### DIFF
--- a/srdb.cli.php
+++ b/srdb.cli.php
@@ -160,7 +160,7 @@ foreach( $options as $key => $value ) {
 	// boolean options as is, eg. a no value arg should be set true
 	if ( in_array( $key, $long_opts ) )
 		$value = true;
-	
+
 	switch ( $key ) {
 		// boolean options.
 		case 'verbose':
@@ -194,12 +194,12 @@ class icit_srdb_cli extends icit_srdb {
 				break;
 			case 'search_replace_table_end':
 				list( $table, $report ) = $args;
-				$time = number_format( $report[ 'end' ] - $report[ 'start' ], 8 );
+				$time = number_format( (float) $report[ 'end' ] - (float) $report[ 'start' ], 8 );
 				$output .= "{$table}: {$report['rows']} rows, {$report['change']} changes found, {$report['updates']} updates made in {$time} seconds";
 				break;
 			case 'search_replace_end':
 				list( $search, $replace, $report ) = $args;
-				$time = number_format( $report[ 'end' ] - $report[ 'start' ], 8 );
+				$time = number_format( (float) $report[ 'end' ] - (float) $report[ 'start' ], 8 );
 				$dry_run_string = $this->dry_run ? "would have been" : "were";
 				$output .= "
 Replacing {$search} with {$replace} on {$report['tables']} tables with {$report['rows']} rows


### PR DESCRIPTION
I was getting:

PHP Notice:  A non well formed numeric value encountered in Search-Replace-DB/srdb.cli.php on line 197

Need to convert to float the report start and end times to remove this error in the log function