### PR TITLE
Ignore $subjects that cannot be multibyte split (#239)

### DIFF
--- a/srdb.class.php
+++ b/srdb.class.php
@@ -1154,6 +1154,10 @@ class icit_srdb {
 
 			foreach ( $searches as $key => $search ) {
 				$parts = mb_split( preg_quote( $search ), $subject );
+				if (false === $parts) {
+					// Unable to split $subject, probably binary data, ignore it.
+					continue;
+				}
 				$count += count( $parts ) - 1;
 				$subject = implode( $replacements[ $key ], $parts );
 			}


### PR DESCRIPTION
This appears to occur when the database field contains binary data. Some wordpress plugins do this, eg [Wordfence](https://www.wordfence.com/)

It appears there are no unit test to cover this case. I considered adding them, but looks like there's a bit of work to get them modernised. Would rather not sink time into that unless the maintainers are on board.

Considered using `mb_detect_encoding`, but it appears there are cases where `mb_detect_encoding` can detect a valid encoding for which `mb_split` still returns `false`.

Not sure if there are cases where we **do** really want to modify binary data, but seems like a pretty risky edge case imo.