### PR TITLE
Fixed error_handler which now terminates script with exit() and exitstatus

### DIFF
--- a/srdb.class.php
+++ b/srdb.class.php
@@ -375,7 +375,8 @@ class icit_srdb {
 
 
 	public function errors( $no, $message, $file, $line ) {
-		echo $message . "\n";
+		echo "Internal Error [$no]: $message in $file on line $line\n";
+		exit($no);
 	}
 
 


### PR DESCRIPTION
This ensures operations are not reported as successful when there are Errors or Warnings (typically caused by changes in PHP core which cause breaking changes in SRDB). By adding exit() to the error_handler callback, wrapper scripts which call `srdb.cli.php` from the command line will properly detect when an error occurs to stop operations.