### PR TITLE
count parameter must be an array or an object that implements cCountable

### DIFF
--- a/srdb.class.php
+++ b/srdb.class.php
@@ -1154,6 +1154,9 @@ class icit_srdb {
 
 			foreach ( $searches as $key => $search ) {
 				$parts = mb_split( preg_quote( $search ), $subject );
+				if (!is_array($parts)) {
+					continue;
+				}
 				$count += count( $parts ) - 1;
 				$subject = implode( $replacements[ $key ], $parts );
 			}


### PR DESCRIPTION
Workaround for issue #271  - managed to use this when migrating a number of sites.