### PR TITLE
Stop looking for primary keys as soon as found

### DIFF
--- a/srdb.class.php
+++ b/srdb.class.php
@@ -1009,7 +1009,7 @@ class icit_srdb {
 		} else {
 			while( $column = $this->db_fetch( $fields ) ) {
 				$columns[] = $column[ 'Field' ];
-				if ( $column[ 'Key' ] == 'PRI' )
+				if ( $column[ 'Key' ] == 'PRI' && $primary_key === null )
 					$primary_key[] = $column[ 'Field' ];
 			}
 		}


### PR DESCRIPTION
This is because in case of structures like this (prestashop, table ps_meta_lang) it fails using using a NON UNIQUE column as primary index... and you can image the mess. https://i.snipboard.io/H4NEcj.jpg

Let me know if you need more details.