### PR TITLE
Fix PHP 7.3 compat break/continue

### DIFF
--- a/srdb.class.php
+++ b/srdb.class.php
@@ -858,7 +858,7 @@ class icit_srdb {
 					case 'utf32':
 						//$encoding = 'utf8';
 						$this->add_error( "The table \"{$table}\" is encoded using \"{$encoding}\" which is currently unsupported.", 'results' );
-						continue;
+						continue 2;
 						break;
 
 					default:


### PR DESCRIPTION
`continue` in switch renders PHP notice for PHP 7.3.
Replaced with `continue 2;`