### PR TITLE
php 7.3 supported. (php 7.1, 5.6 compatible)

### DIFF
--- a/index.php
+++ b/index.php
@@ -2,7 +2,7 @@
 
 /**
  *
- * Safe Search and Replace on Database with Serialized Data v3.1.0
+ * Safe Search and Replace on Database with Serialized Data v3.1.1
  *
  * This script is to solve the problem of doing database search and replace when
  * some data is stored within PHP serialized arrays or objects.
@@ -36,6 +36,18 @@
  * License: GPL v3
  * License URL: http://www.gnu.org/copyleft/gpl.html
  *
+ *
+ * Version 3.1.1:
+ *		* php 7.3 supported. (php 5.6 compatible)
+ *		* supported for php 7.3 Backward incompatible changes.
+ 		  https://www.php.net/manual/en/migration73.incompatible.php
+ *		    Ex) Continue Targeting Switch issues Warning
+ *		* supported for php 7.1 Backward incompatible changes.
+ 		  https://www.php.net/manual/en/migration70.incompatible.php
+ *		    Ex) Changes to list() handling
+ *		* Fixed the problem that error occurs when converting binary type 
+ *		  field of MySQL table. (binary field is skiped.)
+ *		    Ex) WPPlugin: IP Geo Block
  *
  * Version 3.1.0:
  *		* Added port number option to both web and CLI interfaces.
@@ -112,6 +124,17 @@ header( 'HTTP/1.1 200 OK' );
 header('Cache-Control: no-cache, no-store, must-revalidate'); // HTTP 1.1.
 header('Pragma: no-cache'); // HTTP 1.0.
 header('Expires: 0'); // Proxies.
+
+// php 7.x compatible.
+if (!defined('PHP_VERSION_ID')) {
+	$version = explode('.', PHP_VERSION);
+
+	define('PHP_VERSION_ID', ($version[0] * 10000 + $version[1] * 100 + $version[2]));
+
+	define('PHP_MAJOR_VERSION',   $version[0]);
+	define('PHP_MINOR_VERSION',   $version[1]);
+	define('PHP_RELEASE_VERSION', $version[2]);
+}
 
 require_once( 'srdb.class.php' );
 

--- a/srdb.cli.php
+++ b/srdb.cli.php
@@ -185,20 +185,38 @@ class icit_srdb_cli extends icit_srdb {
 
 		switch( $type ) {
 			case 'error':
-				list( $error_type, $error ) = $args;
+				$error_type = $args[1];
+				$error= $args[0];
+				if (PHP_MAJOR_VERSION < 7) {
+					list( $error_type, $error ) = $args;
+				}
 				$output .= "$error_type: $error";
 				break;
 			case 'search_replace_table_start':
-				list( $table, $search, $replace ) = $args;
+				$table = $args[2];
+				$search = $args[1];
+				$replace = $args[0];
+				if (PHP_MAJOR_VERSION < 7) {
+					list( $table, $search, $replace ) = $args;
+				}
 				$output .= "{$table}: replacing {$search} with {$replace}";
 				break;
 			case 'search_replace_table_end':
-				list( $table, $report ) = $args;
+				$table = $args[1];
+				$report = $args[0];
+				if (PHP_MAJOR_VERSION < 7) {
+					list( $table, $report ) = $args;
+				}
 				$time = number_format( $report[ 'end' ] - $report[ 'start' ], 8 );
 				$output .= "{$table}: {$report['rows']} rows, {$report['change']} changes found, {$report['updates']} updates made in {$time} seconds";
 				break;
 			case 'search_replace_end':
-				list( $search, $replace, $report ) = $args;
+				$search = $args[2];
+				$replace = $args[1];
+				$report = $args[0];
+				if (PHP_MAJOR_VERSION < 7) {
+					list( $search, $replace, $report ) = $args;
+				}
 				$time = number_format( $report[ 'end' ] - $report[ 'start' ], 8 );
 				$dry_run_string = $this->dry_run ? "would have been" : "were";
 				$output .= "
@@ -208,11 +226,21 @@ Replacing {$search} with {$replace} on {$report['tables']} tables with {$report[
 It took {$time} seconds";
 				break;
 			case 'update_engine':
-				list( $table, $report, $engine ) = $args;
+				$table = $args[2];
+				$report = $args[1];
+				$engine = $args[0];
+				if (PHP_MAJOR_VERSION < 7) {
+					list( $table, $report, $engine ) = $args;
+				}
 				$output .= $table . ( $report[ 'converted' ][ $table ] ? ' has been' : 'has not been' ) . ' converted to ' . $engine;
 				break;
 			case 'update_collation':
-				list( $table, $report, $collation ) = $args;
+				$table = $args[2];
+				$report = $args[1];
+				$collation = $args[0];
+				if (PHP_MAJOR_VERSION < 7) {
+					list( $table, $report, $collation ) = $args;
+				}
 				$output .= $table . ( $report[ 'converted' ][ $table ] ? ' has been' : 'has not been' ) . ' converted to ' . $collation;
 				break;
 		}


### PR DESCRIPTION
supported for php 7.3 Backward incompatible changes.
https://www.php.net/manual/en/migration73.incompatible.php
  ex) Continue Targeting Switch issues Warning
supported for php 7.1 Backward incompatible changes.
https://www.php.net/manual/en/migration70.incompatible.php
  ex) Changes to list() handling
Fixed the problem that error occurs when converting binary type
field of MySQL table. (binary field is skiped.)
  ex) WordPress Plugin: IP Geo Block