### PR TITLE
SSL props need to be defined

### DIFF
--- a/srdb.class.php
+++ b/srdb.class.php
@@ -126,6 +126,12 @@ class icit_srdb {
     public $port = 0;
     public $charset = 'utf8';
     public $collate = '';
+    public $ssl_key = false;
+    public $ssl_cert = false;
+    public $ssl_ca = false;
+    public $ssl_ca_dir = null;
+    public $ssl_cipher = null;
+    public $debug = false;
 
 
     /**


### PR DESCRIPTION
In PHP 7.3 these undefined properties display warnings.