### PR TITLE
Add script to vendor/bin folder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
             "phpunit"
         ]
     },
+    "bin": [ "srdb.cli.php" ],
     "autoload": {
         "files": [ "srdb.class.php" ]
     }

--- a/srdb.class.php
+++ b/srdb.class.php
@@ -859,6 +859,8 @@ class icit_srdb {
                 return serialize( $data );
             }
 
+        } catch ( Error $error ) {
+            $this->add_error( $error->getMessage(), 'results');
         } catch ( Exception $error ) {
             $this->add_error( $error->getMessage() . ':: This is usually caused by a plugin storing classes as a
 		    serialised string which other PHP classes can\'t then access. It is not possible to unserialise this data


### PR DESCRIPTION
For projects adding Search-Replace-DB as a dependency, composer will now symlink the script into the bin folder.