### PR TITLE
GNU coreutils incompatibility, fixes #337

### DIFF
--- a/srdb.cli.php
+++ b/srdb.cli.php
@@ -1,4 +1,4 @@
-#!/usr/bin/env php -q
+#!/usr/bin/env -S php -q
 <?php
 /*
  * This file is part of Search-Replace-DB.


### PR DESCRIPTION
srdb.cli.php is incompatible with /usr/bin/env from GNU core utils.

Fixes #337