### PR TITLE
suppress PHP warning

### DIFF
--- a/srdb.cli.php
+++ b/srdb.cli.php
@@ -199,7 +199,7 @@ foreach ( $options as $key => $value ) {
         $key = $long_opts_normal[ $is_short ];
     }
 
-    if ( in_array( $key, [ 'search', 'replace' ] ) && is_array( $jsonVal = json_decode( $value, true ) ) ) {
+    if ( in_array( $key, [ 'search', 'replace' ] ) && is_array( $jsonVal = @json_decode( $value, true ) ) ) {
         $args[ $key ] = $jsonVal;
         continue;
     }


### PR DESCRIPTION
Currently a php warning is issued when run with multiple search/replace strings:
```
PHP Warning:  json_decode() expects parameter 1 to be string, array given in ./Search-Replace-DB/srdb.cli.php on line 202
PHP Warning:  json_decode() expects parameter 1 to be string, array given in ./Search-Replace-DB/srdb.cli.php on line 202
```