### PR TITLE
Adds --my-ini-file <file> option to read connection info from mysql INI config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ Type `php srdb.cli.php` to run the program. Type `php srdb.cli.php
     Optional. Port on database server to connect to. The default is
     3306. (MySQL default port).
 
+  --my-ini-file
+    Reads MySQL configuration ini file provided as argument to
+    extract connection parameters (host, user, password, database)
+    from the [client] section. Will not override --host, --name,
+    --user ou --password if provided as CLI argument.
+
   -s, --search
     String to search for or `preg_replace()` style regular
     expression.


### PR DESCRIPTION
I needed a way to provide password without having it in command argument (which could then be read from user users from the server in /proc) to use it in a script.
First approach would have been to accept it from STDIN when using an option, but that approach would be incompatible with any other STDIN usage, and `.my.cnf` files are common enough so that would probably be helpful to someone else.

I tried to match your coding style but it is probably not close enough, sorry about that.