### PR TITLE
fix continue 2

### DIFF
--- a/srdb.class.php
+++ b/srdb.class.php
@@ -1024,17 +1024,17 @@ class icit_srdb {
 
                             if ( in_array( $column, $primary_key ) ) {
                                 $where_sql[] = "`{$column}` = " . $this->db_escape( $data_to_fix );
-                                continue;
+                                continue 2;
                             }
 
                             // exclude cols
                             if ( in_array( $column, $this->exclude_cols ) ) {
-                                continue;
+                                continue 2;
                             }
 
                             // include cols
                             if ( ! empty( $this->include_cols ) && ! in_array( $column, $this->include_cols ) ) {
-                                continue;
+                                continue 2;
                             }
 
                             // Run a search replace on the data that'll respect the serialisation.


### PR DESCRIPTION
I got the same error as described in issue #368. I read [this note](https://www.php.net/manual/en/control-structures.continue.php) and simply added the number `2` after `continue` (except where VS Code marked that as an error). Disclaimer: PHP is not my favourite programming language and I don't know much about it. But I tested the changes and for me, it worked. Anyway, someone more knowledgable should check these.