### PR TITLE
Fix unserialize() warning flood with PHP 8.3+. Fix deprecated warnings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# Version 4.1.4
+ * When using PHP 8.3+, SRDB no longer generates warnings for every string.
+ * Fixed Deprecation warning creating dynamic property: alter_collation.
+ * Fixed Deprecation warning when passing null to htmlentities().
+
 # Version 4.1.3
  * Fix regex search/replace using WebUI
 

--- a/index.php
+++ b/index.php
@@ -455,7 +455,7 @@ class icit_srdb_ui extends icit_srdb {
      * @return string    Escaped string.
      */
     public function esc_html_attr( $string = '', $echo = false ) {
-        $output = htmlentities( $string, ENT_QUOTES, 'UTF-8' );
+        $output = $string ? htmlentities( $string, ENT_QUOTES, 'UTF-8' ) : '';
         if ( $echo ) {
             echo $output;
         } else {


### PR DESCRIPTION
As of PHP 8.3 unserialize() triggers E_WARNING instead of E_NOTICE causing SRDB to dump thousands of notices (one for every string checked) to the screen as it tries to unserialize non-serialized strings. It now checks for serialized data before trying to unserialize.

Fixed Deprecation warning creating dynamic property: alter_collation.

Fixed Deprecation warning when passing null to htmlentities().