### PR TITLE
tablename with dash breaks class because not backtick quoted in two p…

### DIFF
--- a/srdb.class.php
+++ b/srdb.class.php
@@ -1067,7 +1067,7 @@ class icit_srdb {
                             // nothing for this state
                         } elseif ( $update && ! empty( $where_sql ) ) {
 
-                            $sql = 'UPDATE ' . $table . ' SET ' . implode( ', ',
+                            $sql = 'UPDATE `' . $table . '` SET ' . implode( ', ',
                                     $update_sql ) . ' WHERE ' . implode( ' AND ', array_filter( $where_sql ) );
 
                             $result = $this->db_update( $sql );
@@ -1114,7 +1114,7 @@ class icit_srdb {
         $columns     = array();
 
         // Get a list of columns in this table
-        $fields = $this->db_query( "DESCRIBE {$table}" );
+        $fields = $this->db_query( "DESCRIBE `{$table}`" );
         if ( ! $fields ) {
             $this->add_error( $this->db_error(), 'db' );
         } else {


### PR DESCRIPTION
Resolves issue #382 

If a table or column name has a '-' in it, MySQL requires the name to be backtick quoted.   Trying to use srdb.class.php on tables with - in them crashes the class. 