### PR TITLE
Fix fatal error when composer lib is included for use with Wordpress

### DIFF
--- a/srdb.class.php
+++ b/srdb.class.php
@@ -841,7 +841,7 @@ class icit_srdb {
         // some unserialised data cannot be re-serialised eg. SimpleXMLElements
         try {
             // If this looks like serialized data, try to unserialize it.
-            $unserialized = $this->is_serialized( $data ) ? @unserialize( $data ) : false;
+            $unserialized = self::is_serialized( $data ) ? @unserialize( $data ) : false;
             
             if ( $unserialized !== false ) {
                 $data = $this->recursive_unserialize_replace( $from, $to, $unserialized, true );
@@ -1356,7 +1356,7 @@ class icit_srdb {
      * @param bool   $strict Optional. Whether to be strict about the end of the string. Default true.
      * @return bool False if not serialized and true if it was.
      */
-    public function is_serialized( $data, $strict = true ) {
+    public static function is_serialized( $data, $strict = true ) {
         // If it isn't a string, it isn't serialized.
         if ( ! is_string( $data ) ) {
             return false;

--- a/srdb.class.php
+++ b/srdb.class.php
@@ -841,7 +841,7 @@ class icit_srdb {
         // some unserialised data cannot be re-serialised eg. SimpleXMLElements
         try {
             // If this looks like serialized data, try to unserialize it.
-            $unserialized = is_serialized( $data ) ? @unserialize( $data ) : false;
+            $unserialized = $this->is_serialized( $data ) ? @unserialize( $data ) : false;
             
             if ( $unserialized !== false ) {
                 $data = $this->recursive_unserialize_replace( $from, $to, $unserialized, true );
@@ -1342,6 +1342,80 @@ class icit_srdb {
         return $string;
     }
 
+    // is_serialized() is cloned from WordPress: wp-includes/functions.php
+	/**
+	 * Checks value to find if it was serialized.
+	 *
+	 * If $data is not a string, then returned value will always be false.
+     * Serialized data is always a string.
+     *
+     * @since 2.0.5
+     * @since 6.1.0 Added Enum support.
+     *
+     * @param string $data   Value to check to see if was serialized.
+     * @param bool   $strict Optional. Whether to be strict about the end of the string. Default true.
+     * @return bool False if not serialized and true if it was.
+     */
+    public function is_serialized( $data, $strict = true ) {
+        // If it isn't a string, it isn't serialized.
+        if ( ! is_string( $data ) ) {
+            return false;
+        }
+        $data = trim( $data );
+        if ( 'N;' === $data ) {
+            return true;
+        }
+        if ( strlen( $data ) < 4 ) {
+            return false;
+        }
+        if ( ':' !== $data[1] ) {
+            return false;
+        }
+        if ( $strict ) {
+            $lastc = substr( $data, -1 );
+            if ( ';' !== $lastc && '}' !== $lastc ) {
+                return false;
+            }
+        } else {
+            $semicolon = strpos( $data, ';' );
+            $brace     = strpos( $data, '}' );
+            // Either ; or } must exist.
+            if ( false === $semicolon && false === $brace ) {
+                return false;
+            }
+            // But neither must be in the first X characters.
+            if ( false !== $semicolon && $semicolon < 3 ) {
+                return false;
+            }
+            if ( false !== $brace && $brace < 4 ) {
+                return false;
+            }
+        }
+        $token = $data[0];
+        switch ( $token ) {
+            case 's':
+                if ( $strict ) {
+                    if ( '"' !== substr( $data, -2, 1 ) ) {
+                        return false;
+                    }
+                } elseif ( ! str_contains( $data, '"' ) ) {
+                    return false;
+                }
+                // Or else fall through.
+            case 'a':
+            case 'O':
+            case 'E':
+                return (bool) preg_match( "/^{$token}:[0-9]+:/s", $data );
+            case 'b':
+            case 'i':
+            case 'd':
+                $end = $strict ? '$' : '';
+                return (bool) preg_match( "/^{$token}:[0-9.E+-]+;$end/", $data );
+        }
+        return false;
+    }
+
+
 
 }
 
@@ -1364,81 +1438,4 @@ function object_serializer( $class_name ) {
     }
 
     eval( $namespace . "class {$class_name} extends \ArrayObject {}" );
-}
-
-
-// is_serialized() is cloned from WordPress: wp-includes/functions.php
-    
-if( !is_callable('is_serialized') ) {
-/**
- * Checks value to find if it was serialized.
- *
- * If $data is not a string, then returned value will always be false.
- * Serialized data is always a string.
- *
- * @since 2.0.5
- * @since 6.1.0 Added Enum support.
- *
- * @param string $data   Value to check to see if was serialized.
- * @param bool   $strict Optional. Whether to be strict about the end of the string. Default true.
- * @return bool False if not serialized and true if it was.
- */
-function is_serialized( $data, $strict = true ) {
-    // If it isn't a string, it isn't serialized.
-    if ( ! is_string( $data ) ) {
-        return false;
-    }
-    $data = trim( $data );
-    if ( 'N;' === $data ) {
-        return true;
-    }
-    if ( strlen( $data ) < 4 ) {
-        return false;
-    }
-    if ( ':' !== $data[1] ) {
-        return false;
-    }
-    if ( $strict ) {
-        $lastc = substr( $data, -1 );
-        if ( ';' !== $lastc && '}' !== $lastc ) {
-            return false;
-        }
-    } else {
-        $semicolon = strpos( $data, ';' );
-        $brace     = strpos( $data, '}' );
-        // Either ; or } must exist.
-        if ( false === $semicolon && false === $brace ) {
-            return false;
-        }
-        // But neither must be in the first X characters.
-        if ( false !== $semicolon && $semicolon < 3 ) {
-            return false;
-        }
-        if ( false !== $brace && $brace < 4 ) {
-            return false;
-        }
-    }
-    $token = $data[0];
-    switch ( $token ) {
-        case 's':
-            if ( $strict ) {
-                if ( '"' !== substr( $data, -2, 1 ) ) {
-                    return false;
-                }
-            } elseif ( ! str_contains( $data, '"' ) ) {
-                return false;
-            }
-            // Or else fall through.
-        case 'a':
-        case 'O':
-        case 'E':
-            return (bool) preg_match( "/^{$token}:[0-9]+:/s", $data );
-        case 'b':
-        case 'i':
-        case 'd':
-            $end = $strict ? '$' : '';
-            return (bool) preg_match( "/^{$token}:[0-9.E+-]+;$end/", $data );
-    }
-    return false;
-}
 }

--- a/srdb.class.php
+++ b/srdb.class.php
@@ -841,7 +841,7 @@ class icit_srdb {
         // some unserialised data cannot be re-serialised eg. SimpleXMLElements
         try {
             // If this looks like serialized data, try to unserialize it.
-            $unserialized = self::is_serialized( $data ) ? @unserialize( $data ) : false;
+            $unserialized = $this->is_serialized( $data ) ? @unserialize( $data ) : false;
             
             if ( $unserialized !== false ) {
                 $data = $this->recursive_unserialize_replace( $from, $to, $unserialized, true );
@@ -1356,7 +1356,7 @@ class icit_srdb {
      * @param bool   $strict Optional. Whether to be strict about the end of the string. Default true.
      * @return bool False if not serialized and true if it was.
      */
-    public static function is_serialized( $data, $strict = true ) {
+    public function is_serialized( $data, $strict = true ) {
         // If it isn't a string, it isn't serialized.
         if ( ! is_string( $data ) ) {
             return false;


### PR DESCRIPTION
Declaring is_serialized in the global scope fatals Wordpress as it can't declare it again.  Move is_serialized to public class method.

Static method or not?  Not sure where else in the package needs is_serialized

NEEDS MORE TESTING!

